### PR TITLE
adding manual examples as test files

### DIFF
--- a/tst/example1.tst
+++ b/tst/example1.tst
@@ -1,0 +1,65 @@
+##############################################################################
+##
+#W  example1.tst                 KBMag Package                      Derek Holt
+##
+gap> START_TEST( "KBMag package: example1.tst" );
+gap> fsa_infolevel_saved := InfoLevel( InfoFSA );; 
+gap> SetInfoLevel( InfoFSA, 0 );; 
+gap> rws_infolevel_saved := InfoLevel( InfoRWS );; 
+gap> SetInfoLevel( InfoRWS, 0 );; 
+
+gap> ## SubSection 1.9, Example 1  
+gap> ## We start with a easy example - the alternating group A4.
+gap> F := FreeGroup( "a", "b" );;
+gap> a := F.1;; b := F.2;;
+gap> G := F/[ a^2, b^3, (a*b)^3 ];;
+gap> R := KBMAGRewritingSystem( G );
+rec(
+           isRWS := true,
+          silent := true,
+  generatorOrder := [_g1,_g2,_g3],
+        inverses := [_g1,_g3,_g2],
+        ordering := "shortlex",
+       equations := [
+         [_g2^2,_g3],
+         [_g1*_g2*_g1,_g3*_g1*_g3]
+       ]
+)
+gap> ## Notice that monoid generators printed as _g1, _g2, _g3 are used
+gap> ## internally. These correspond to the group generators a, b, b^-1.
+gap> KnuthBendix( R );
+true
+gap> R;
+rec(
+           isRWS := true,
+     isConfluent := true,
+          silent := true,
+  generatorOrder := [_g1,_g2,_g3],
+        inverses := [_g1,_g3,_g2],
+        ordering := "shortlex",
+       equations := [
+         [_g1^2,IdWord],
+         [_g2*_g3,IdWord],
+         [_g3*_g2,IdWord],
+         [_g2^2,_g3],
+         [_g3*_g1*_g3,_g1*_g2*_g1],
+         [_g3^2,_g2],
+         [_g2*_g1*_g2,_g1*_g3*_g1],
+         [_g3*_g1*_g2*_g1,_g2*_g1*_g3],
+         [_g1*_g2*_g1*_g3,_g3*_g1*_g2],
+         [_g2*_g1*_g3*_g1,_g3*_g1*_g2],
+         [_g1*_g3*_g1*_g2,_g2*_g1*_g3]
+       ]
+)
+gap> ## The ‘equations’ field of <R> is now a complete system of rewriting rules
+gap> Size(R);
+12
+gap> EnumerateReducedWords(R,0,12);
+[ <identity ...>, a, a*b, a*b*a, a*b^-1, a*b^-1*a, b, b*a, b*a*b^-1, b^-1,
+  b^-1*a, b^-1*a*b ]
+gap> ## We have enumerated all of the elements of the group - 
+gap> ## note that they are returned as words in the free group F.
+
+gap> ## SetInfoLevel( InfoFSA, fsa_infolevel_saved );; 
+gap> ## SetInfoLevel( InfoRWS, rws_infolevel_saved );; 
+gap> STOP_TEST( "example1.tst", 10000 );

--- a/tst/example2.tst
+++ b/tst/example2.tst
@@ -1,0 +1,51 @@
+##############################################################################
+##
+#W  example2.tst                 KBMag Package                      Derek Holt
+##
+gap> START_TEST( "KBMag package: example2.tst" );
+gap> fsa_infolevel_saved := InfoLevel( InfoFSA );; 
+gap> SetInfoLevel( InfoFSA, 0 );; 
+gap> rws_infolevel_saved := InfoLevel( InfoRWS );; 
+gap> SetInfoLevel( InfoRWS, 0 );; 
+
+gap> ## SubSection 1.9, Example 2 
+gap> ## The Fibonacci group F(2, 5) defined by a semigroup rather than a 
+gap> ## group presentation. Interestingly this defines the same structure 
+gap> ## (although it would not do so for F(2, r) with r even).
+gap> S := FreeSemigroup( 5 );; 
+gap> a:=S.1;;  b:=S.2;;  c:=S.3;;  d:=S.4;;  e:=S.5;;
+gap> Q := S/[ [a*b,c], [b*c,d], [c*d,e], [d*e,a], [e*a,b] ];
+<fp semigroup on the generators [ s1, s2, s3, s4, s5 ]>
+gap> R:=KBMAGRewritingSystem(Q);
+rec(
+           isRWS := true,
+          silent := true,
+  generatorOrder := [_s1,_s2,_s3,_s4,_s5],
+        inverses := [,,,,],
+        ordering := "shortlex",
+       equations := [
+         [_s1*_s2,_s3],
+         [_s2*_s3,_s4],
+         [_s3*_s4,_s5],
+         [_s4*_s5,_s1],
+         [_s5*_s1,_s2]
+       ]
+)
+gap> KnuthBendix( R );
+true
+gap> Size( R );
+11
+gap> EnumerateReducedWords( R, 0, 4 );
+[ s1, s1^2, s1^2*s4, s1*s3, s1*s4, s2, s2^2, s2*s5, s3, s4, s5 ]
+gap> ## Let’s do the same thing using the "recursive" ordering.
+gap> SetOrderingOfKBMAGRewritingSystem( R, "recursive" );
+gap> KnuthBendix( R );
+true
+gap> Size( R );
+11
+gap> EnumerateReducedWords( R, 0, 11 );
+[ s1, s1^2, s1^3, s1^4, s1^5, s1^6, s1^7, s1^8, s1^9, s1^10, s1^11 ]
+
+gap> ## SetInfoLevel( InfoFSA, fsa_infolevel_saved );; 
+gap> ## SetInfoLevel( InfoRWS, rws_infolevel_saved );; 
+gap> STOP_TEST( "example2.tst", 10000 );

--- a/tst/example3.tst
+++ b/tst/example3.tst
@@ -1,0 +1,93 @@
+##############################################################################
+##
+#W  example3.tst                 KBMag Package                      Derek Holt
+##
+gap> START_TEST( "KBMag package: example3.tst" );
+gap> fsa_infolevel_saved := InfoLevel( InfoFSA );; 
+gap> SetInfoLevel( InfoFSA, 0 );; 
+gap> rws_infolevel_saved := InfoLevel( InfoRWS );; 
+gap> SetInfoLevel( InfoRWS, 0 );; 
+
+gap> ## SubSection 1.9, Example 3 
+gap> ## The Heisenberg group - that is, the free 2-generator nilpotent 
+gap> ## group of class 2. For this to complete, we need to use the recursive 
+gap> ## ordering, and reverse our initial order of generators. 
+gap> ## (Alternatively, we could avoid this reversal, by using a “wreathprod” 
+gap> ## ordering, and setting the levels of the generators to be 6,5,4,3,2,1.) 
+gap> F := FreeGroup( "x", "y", "z" );;
+gap> x:=F.1;;  y:=F.2;;  z:=F.3;;
+gap> G := F/[Comm(y,x)*z^-1, Comm(z,x), Comm(z,y)];;
+gap> R := KBMAGRewritingSystem( G );
+rec(
+           isRWS := true,
+          silent := true,
+  generatorOrder := [_g1,_g2,_g3,_g4,_g5,_g6],
+        inverses := [_g2,_g1,_g4,_g3,_g6,_g5],
+        ordering := "shortlex",
+       equations := [
+         [_g4*_g2*_g3,_g5*_g2],
+         [_g6*_g2,_g2*_g6],
+         [_g6*_g4,_g4*_g6]
+       ]
+)
+gap> SetOrderingOfKBMAGRewritingSystem( R, "recursive" );
+gap> ReorderAlphabetOfKBMAGRewritingSystem( R, (1,6)(2,5)(3,4) );
+gap> R;
+rec(
+           isRWS := true,
+          silent := true,
+  generatorOrder := [_g6,_g5,_g4,_g3,_g2,_g1],
+        inverses := [_g5,_g6,_g3,_g4,_g1,_g2],
+        ordering := "recursive",
+       equations := [
+         [_g4*_g2*_g3,_g5*_g2],
+         [_g6*_g2,_g2*_g6],
+         [_g6*_g4,_g4*_g6]
+       ]
+)
+gap> SetInfoLevel( InfoRWS, 1 );
+gap> KnuthBendix( R );
+#I  Calling external Knuth-Bendix program.
+#I  External Knuth-Bendix program complete.
+#I  System computed is confluent.
+true
+gap> R;
+rec(
+           isRWS := true,
+     isConfluent := true,
+  generatorOrder := [_g6,_g5,_g4,_g3,_g2,_g1],
+        inverses := [_g5,_g6,_g3,_g4,_g1,_g2],
+        ordering := "recursive",
+       equations := [
+         [_g6*_g5,IdWord],
+         [_g5*_g6,IdWord],
+         [_g4*_g3,IdWord],
+         [_g3*_g4,IdWord],
+         [_g2*_g1,IdWord],
+         [_g1*_g2,IdWord],
+         [_g6*_g2,_g2*_g6],
+         [_g6*_g4,_g4*_g6],
+         [_g4*_g2,_g2*_g4*_g5],
+         [_g5*_g2,_g2*_g5],
+         [_g6*_g1,_g1*_g6],
+         [_g5*_g4,_g4*_g5],
+         [_g6*_g3,_g3*_g6],
+         [_g3*_g1,_g1*_g3*_g5],
+         [_g4*_g1,_g1*_g4*_g6],
+         [_g3*_g2,_g2*_g3*_g6],
+         [_g5*_g1,_g1*_g5],
+         [_g5*_g3,_g3*_g5]
+       ]
+)
+gap> Size( R );
+infinity
+gap> IsReducedWord( R, z*y*x );
+false
+gap> ReducedForm( R, z*y*x );
+x*y*z^2
+gap> IsReducedForm( R, x*y*z^2 );
+true
+
+gap> ## SetInfoLevel( InfoFSA, fsa_infolevel_saved );; 
+gap> ## SetInfoLevel( InfoRWS, rws_infolevel_saved );; 
+gap> STOP_TEST( "example3.tst", 10000 );

--- a/tst/example4.tst
+++ b/tst/example4.tst
@@ -1,0 +1,84 @@
+##############################################################################
+##
+#W  example4.tst                 KBMag Package                      Derek Holt
+##
+gap> START_TEST( "KBMag package: example4.tst" );
+gap> fsa_infolevel_saved := InfoLevel( InfoFSA );; 
+gap> SetInfoLevel( InfoFSA, 0 );; 
+gap> rws_infolevel_saved := InfoLevel( InfoRWS );; 
+gap> SetInfoLevel( InfoRWS, 0 );; 
+
+gap> ## SubSection 1.9, Example 4 
+gap> ## This is an example of the use of the Knuth-Bendix algorithm 
+gap> ## to prove the nilpotence of a finitely presented group. 
+gap> ## (The method is due to Sims, described in Chapter 11.8 of [Sim94].) 
+gap> ## This example is of intermediate difficulty, and demonstrates the 
+gap> ## necessity of using the maxstoredlen control parameter.
+gap> ## The group is ⟨a,b|[b,a,b],[b,a,a,a,a],[b,a,a,a,b,a,a]⟩ 
+gap> ## with left-normed commutators. The first step in the method is to 
+gap> ## check that there is a maximal nilpotent quotient of the group, 
+gap> ## for which we could use, for example, the GAP NilpotentQuotient command, 
+gap> ## from the package “nq”. We find that there is a maximal such quotient, 
+gap> ## and it has class 7, and the layers going down the lower central series 
+gap> ## have the abelian structures [0,0], [0], [0], [0], [0], [2], [2]. 
+gap> ## By using the stand-alone C nilpotent quotient program, it is possible 
+gap> ## to find a power-commutator presentation of this maximal quotient. 
+gap> ## We now construct a new presentation of the same group, by introducing 
+gap> ## the generators in this power-commutator presentation, together with 
+gap> ## their definitions as powers or commutators of earlier generators. 
+gap> ## This new presentation that we use as input for the Knuth-Bendix program. 
+gap> ## Again we use the recursive ordering, but this time we will be careful 
+gap> ## to introduce the generators in the correct order in the first place!
+gap> ## 
+gap> F := FreeGroup( "h", "g", "f", "e", "d", "c", "b", "a" );;
+gap> h:=F.1;;  g:=F.2;;  f:=F.3;;  e:=F.4;; 
+gap> d:=F.5;;  c:=F.6;;  b:=F.7;;  a:=F.8;;
+gap> G := F/[Comm(b,a)*c^-1, Comm(c,a)*d^-1, Comm(d,a)*e^-1,
+>            Comm(e,b)*f^-1, Comm(f,a)*g^-1, Comm(g,b)*h^-1,
+>            Comm(g,a), Comm(c,b), Comm(e,a)];;
+gap> R := KBMAGRewritingSystem( G );
+rec(
+           isRWS := true,
+  generatorOrder := [_g1,_g2,_g3,_g4,_g5,_g6,_g7,_g8,_g9,_g10,_g11,_g12,_g13,
+                     _g14,_g15,_g16],
+        inverses := [_g2,_g1,_g4,_g3,_g6,_g5,_g8,_g7,_g10,_g9,_g12,_g11,_g14,
+                     _g13,_g16,_g15],
+        ordering := "shortlex",
+       equations := [
+         [_g14*_g16*_g13,_g11*_g16],
+         [_g12*_g16*_g11,_g9*_g16],
+         [_g10*_g16*_g9,_g7*_g16],
+         [_g8*_g14*_g7,_g5*_g14],
+         [_g6*_g16*_g5,_g3*_g16],
+         [_g4*_g14*_g3,_g1*_g14],
+         [_g4*_g16,_g16*_g4],
+         [_g12*_g14,_g14*_g12],
+         [_g8*_g16,_g16*_g8]
+       ]
+)
+gap> SetOrderingOfKBMAGRewritingSystem( R, "recursive" );
+gap> ## A little experimentation reveals that this example works best 
+gap> ## when only those equations with left and right hand sides of 
+gap> ## lengths at most 10 are kept.
+gap> O := OptionsRecordOfKBMAGRewritingSystem( R );;
+gap> O.maxstoredlen := [10,10];;
+gap> SetInfoLevel( InfoRWS, 2 );
+gap> KnuthBendix( R );
+false 
+gap> ## Now it is essential to re-run with the ‘maxstoredlen’ limit removed 
+gap> ## to check that the system really is confluent.
+gap> Unbind( O.maxstoredlen );
+gap> KnuthBendix( R );
+#I  External Knuth-Bendix program complete.
+#I  System computed is confluent.
+true
+gap> ## #In fact, in this case, we did have a confluent set already. 
+gap> ## Inspection of the confluent set now reveals it to be precisely 
+gap> ## a power-commutator presentation of a nilpotent group, and so we 
+gap> ## have proved that the group we started with really is nilpotent. 
+gap> ## Of course, this means also that it is equal to its largest 
+gap> ## nilpotent quotient, of which we already know the structure.
+
+gap> ## SetInfoLevel( InfoFSA, fsa_infolevel_saved );; 
+gap> ## SetInfoLevel( InfoRWS, rws_infolevel_saved );; 
+gap> STOP_TEST( "example4.tst", 10000 );

--- a/tst/example5.tst
+++ b/tst/example5.tst
@@ -1,0 +1,49 @@
+##############################################################################
+##
+#W  example5.tst                 KBMag Package                      Derek Holt
+##
+gap> START_TEST( "KBMag package: example5.tst" );
+gap> fsa_infolevel_saved := InfoLevel( InfoFSA );; 
+gap> SetInfoLevel( InfoFSA, 0 );; 
+gap> rws_infolevel_saved := InfoLevel( InfoRWS );; 
+gap> SetInfoLevel( InfoRWS, 0 );; 
+
+gap> ## SubSection 1.9, Example 5 
+gap> ## Our final example illustrates the use of the AutomaticStructure 
+gap> ## command, which runs the automatic groups programs. The group has a 
+gap> ## balanced symmetrical presentation with 3 generators and 3 relators, 
+gap> ## and was originally pro- posed by Heineken as a possible example of 
+gap> ## a finite group with such a presentation. 
+gap> ## In fact, the AutomaticStructure command proves it to be infinite.
+gap> ## 
+gap> F := FreeGroup( "a", "b", "c" );;
+gap> a:=F.1;;  b:=F.2;;  c:=F.3;;
+gap> G := F/[ Comm(a,Comm(a,b))*c^-1, Comm(b,Comm(b,c))*a^-1,
+>             Comm(c,Comm(c,a))*b^-1 ];;
+gap> R := KBMAGRewritingSystem( G );
+rec(
+           isRWS := true,
+         verbose := true,
+  generatorOrder := [_g1,_g2,_g3,_g4,_g5,_g6],
+        inverses := [_g2,_g1,_g4,_g3,_g6,_g5],
+        ordering := "shortlex",
+       equations := [
+         [_g2*_g4*_g2*_g3*_g1,_g5*_g4*_g2*_g3],
+         [_g4*_g6*_g4*_g5*_g3,_g1*_g6*_g4*_g5],
+         [_g6*_g2*_g6*_g1*_g5,_g3*_g2*_g6*_g1]
+       ]
+)
+gap> ## SetInfoLevel( InfoRWS, 1 );
+gap> AutomaticStructure( R, true );
+true
+gap> Size( R );
+infinity
+gap> Order( R, a );
+infinity
+gap> Order( R, Comm(a,b) );
+infinity
+
+gap> #
+gap> ## SetInfoLevel( InfoFSA, fsa_infolevel_saved );; 
+gap> ## SetInfoLevel( InfoRWS, rws_infolevel_saved );; 
+gap> STOP_TEST( "example5.tst", 10000 );

--- a/tst/example6.tst
+++ b/tst/example6.tst
@@ -1,0 +1,58 @@
+##############################################################################
+##
+#W  example6.tst                 KBMag Package                      Derek Holt
+##
+gap> START_TEST( "KBMag package: example6.tst" );
+gap> fsa_infolevel_saved := InfoLevel( InfoFSA );; 
+gap> SetInfoLevel( InfoFSA, 0 );; 
+gap> rws_infolevel_saved := InfoLevel( InfoRWS );; 
+gap> SetInfoLevel( InfoRWS, 0 );; 
+
+gap> ## SubSection 1.15, Example 1  
+gap> F := FreeGroup( "a", "b", "c" );;
+gap> a:=F.1;;  b:=F.2;;  c:=F.3;;
+gap> G := F/[b^3,c^3,(b*c)^4,(b*c^-1)^5,a^-1*b^-1*c*b*c*b^-1*c*b*c^-1];
+<fp group on the generators [ a, b, c ]>
+gap> R := KBMAGRewritingSystem( G );
+rec(
+           isRWS := true,
+          silent := true,
+  generatorOrder := [_g1,_g2,_g3,_g4,_g5,_g6],
+        inverses := [_g2,_g1,_g4,_g3,_g6,_g5],
+        ordering := "shortlex",
+       equations := [
+         [_g3^2,_g4],
+         [_g5^2,_g6],
+         [(_g3*_g5)^2,(_g6*_g4)^2],
+         [(_g3*_g6)^2*_g3,(_g5*_g4)^2*_g5],
+         [_g2*_g4*_g5*_g3*_g5,_g5*_g4*_g6*_g3]
+       ]
+)
+gap> S := SubgroupOfKBMAGRewritingSystem( R, [ a^3, c*a^2 ] );
+rec(
+           isRWS := true,
+          silent := true,
+  generatorOrder := [_x1,_X1,_x2,_X2],
+        inverses := [_X1,_x1,_X2,_x2],
+        ordering := "shortlex",
+       equations := [
+       ]
+)
+gap> KnuthBendixOnCosetsWithSubgroupRewritingSystem( R, S );
+true
+gap> Index( R, S );
+18
+gap> IsReducedCosetRepresentative( R, S, b*a*b*a );
+false
+gap> ReducedFormOfCosetRepresentative( R, S, b*a*b*a );
+b^-1*a^-1
+gap> EnumerateReducedCosetRepresentatives( R, S, 0, 4 );
+[ <identity ...>, a, a*b, a*b*c, a*b^-1, a^-1, a^-1*b, a^-1*b*c, a^-1*b^-1,
+  b, b*c, b*c*a, b*c*a^-1, b*c^-1, b^-1, b^-1*a, b^-1*a^-1, b^-1*a^-1*b ]
+gap> SS := RewritingSystemOfSubgroupOfKBMAGRewritingSystem( R, S );;
+gap> Size( SS );
+60
+
+gap> ## SetInfoLevel( InfoFSA, fsa_infolevel_saved );; 
+gap> ## SetInfoLevel( InfoRWS, rws_infolevel_saved );; 
+gap> STOP_TEST( "example6.tst", 10000 );

--- a/tst/example7.tst
+++ b/tst/example7.tst
@@ -1,0 +1,30 @@
+##############################################################################
+##
+#W  example7.tst                 KBMag Package                      Derek Holt
+##
+gap> START_TEST( "KBMag package: example7.tst" );
+gap> fsa_infolevel_saved := InfoLevel( InfoFSA );; 
+gap> SetInfoLevel( InfoFSA, 0 );; 
+gap> rws_infolevel_saved := InfoLevel( InfoRWS );; 
+gap> SetInfoLevel( InfoRWS, 0 );; 
+
+gap> ## SubSection 1.15, Example 2  
+gap> ## We find a free subgroup of the Fibonacci group F(2, 8). 
+gap> ## This example may take about 20 minutes to run on a typical WorkStation.
+gap> F := FreeGroup( 8 );;
+gap> a:=F.1;; b:=F.2;; c:=F.3;; d:=F.4;; e:=F.5;; f:=F.6;; g:=F.7;; h:=F.8;;
+gap> G := F/[ a*b*c^-1, b*c*d^-1, c*d*e^-1, d*e*f^-1,
+>             e*f*g^-1, f*g*h^-1, g*h*a^-1, h*a*b^-1 ];;
+gap> R := KBMAGRewritingSystem( G );;
+gap> S := SubgroupOfKBMAGRewritingSystem( R, [a,e] );;
+gap> AutomaticStructureOnCosetsWithSubgroupPresentation( R, S );
+gap> P := PresentationOfSubgroupOfKBMAGRewritingSystem( R, S );
+<fp group on the generators [ f1, f3 ]>
+gap> RelatorsOfFpGroup( P );
+[]
+gap> Index( R, S );
+infinity
+
+gap> ## SetInfoLevel( InfoFSA, fsa_infolevel_saved );; 
+gap> ## SetInfoLevel( InfoRWS, rws_infolevel_saved );; 
+gap> STOP_TEST( "example7.tst", 10000 );

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -1,0 +1,10 @@
+##############################################################################
+##
+#W  testall.g                     KBMag Package                    Derek Holt
+##
+
+LoadPackage( "kbmag" ); 
+dir := DirectoriesPackageLibrary("kbmag","tst");
+TestDirectory(dir, rec(exitGAP := true,
+    testOptions:=rec(compareFunction := "uptowhitespace")));
+FORCE_QUIT_GAP(1);

--- a/tst/testing.g
+++ b/tst/testing.g
@@ -1,0 +1,32 @@
+##############################################################################
+##
+#W  testing.g                      KBMag Package                    Derek Holt
+##
+
+LoadPackage( "kbmag" );
+
+TestKBMag := function( pkgname )
+    local  pkgdir, testfiles, testresult, ff, fn;
+    LoadPackage( pkgname );
+    pkgdir := DirectoriesPackageLibrary( pkgname, "tst" );
+    # Arrange chapters as required
+    testfiles := 
+        [ "example1.tst", "example2.tst", "example3.tst", "example4.tst", 
+          "example5.tst" ];
+    testresult := true;
+    for ff in testfiles do
+        fn := Filename( pkgdir, ff );
+        Print( "#I  Testing ", fn, "\n" );
+        if not Test( fn, rec(compareFunction := "uptowhitespace") ) then
+            testresult := false;
+        fi;
+    od;
+    if testresult then
+        Print("#I  No errors detected while testing package ", pkgname, "\n");
+    else
+        Print("#I  Errors detected while testing package ", pkgname, "\n");
+    fi;
+end;
+
+##  Set the name of the package here
+TestKBMag( "kbmag" );


### PR DESCRIPTION
Manual examples 1,2,3,4,5 (section 1.9) and 1,2 (section 1.15) added as tst/example1.tst, ..., tst/example7.tst.  Also added tst/testall.g and tst/testing.g.  (Probably should have commented out the SetInfoLevel lines.)  Examples 4,5,7 fail to work correctly on my system.  Hopefully that is just here? 